### PR TITLE
Do not default to version 1

### DIFF
--- a/Sitecore.SharedSource.WebApiClient/Sitecore.SharedSource.WebApiClient/Data/SitecoreQuery.cs
+++ b/Sitecore.SharedSource.WebApiClient/Sitecore.SharedSource.WebApiClient/Data/SitecoreQuery.cs
@@ -133,7 +133,7 @@ namespace Sitecore.SharedSource.WebApiClient.Data
         /// </value>
         public int ItemVersion
         {
-            get { return _itemVersion > 0 ? _itemVersion : 1; }
+            get { return _itemVersion >= 0 ? _itemVersion : 1; }
             set { _itemVersion = value; }
         }
 
@@ -215,11 +215,15 @@ namespace Sitecore.SharedSource.WebApiClient.Data
                                      {
                                          { Structs.QueryStringKeys.Database, Database },
                                          { Structs.QueryStringKeys.ExtractBlob, ExtractBlob.ToIntString() },
-                                         { Structs.QueryStringKeys.ItemVersion,ItemVersion.ToString(CultureInfo.InvariantCulture) },
                                          { Structs.QueryStringKeys.Language, Language },
                                          { Structs.QueryStringKeys.Payload, Payload.ToString() },
                                          { Structs.QueryStringKeys.Scope, string.Join("|", QueryScope.Select(x => x.ToScopeParameter())) }
                                      };
+
+                if (ItemVersion > 0)
+                {
+                    dictionary.Add(Structs.QueryStringKeys.ItemVersion, ItemVersion.ToString(CultureInfo.InvariantCulture));
+                }
 
                 // the Sitecore web service will return a 500 code if specifying a page size <= 0
                 if (PageSize > 0)


### PR DESCRIPTION
When an item has 2 versions, the current version of the code will always update version 1.
